### PR TITLE
feat: add support for extras and git tag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,4 +15,4 @@ def dirs() -> Path:
 
 @pytest.fixture
 def rye() -> str:
-    return f"{os.getenv("HOME")}/.rye/shims/rye"
+    return f'{os.getenv("HOME")}/.rye/shims/rye'


### PR DESCRIPTION
Adds support for `extras` and `tag`.

## Example 1:

`sqlalchemy = { extras = ["asyncio"], version = "^2.0.31" }`

## Example 2:

`sqlalchemy = { git = "https://github.com/sqlalchemy/sqlalchemy.git", tag = "2.0.31", extras = ["asyncio"] }`

# Note

Feel free to copy/refactor/modify my changes.