### PR TITLE
Ignore src creation, use tomlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 dependencies = [
     "python-slugify~=8.0.1",
-    "pyproject-parser~=0.11.0",
     "pydantic~=1.10.8",
     "poetry-core>=1.9.0",
     "tomlkit~=0.11.8",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,13 +10,6 @@
 #   universal: false
 
 -e file:.
-apeye==1.3.0
-    # via shippinglabel
-apeye-core==1.1.2
-    # via apeye
-    # via pyproject-parser
-attrs==23.1.0
-    # via pyproject-parser
 black==23.3.0
 build==1.2.1
     # via poetry
@@ -24,33 +17,21 @@ cachecontrol==0.14.0
     # via poetry
 certifi==2023.5.7
     # via requests
+cffi==1.17.1
+    # via cryptography
 charset-normalizer==3.1.0
     # via requests
 cleo==2.1.0
     # via poetry
 click==8.1.3
     # via black
-colorama==0.4.6
-    # via build
-    # via click
-    # via pytest
 crashtest==0.4.1
     # via cleo
     # via poetry
-dist-meta==0.8.0
-    # via shippinglabel
+cryptography==44.0.0
+    # via secretstorage
 distlib==0.3.8
     # via virtualenv
-dom-toml==2.0.0
-    # via pyproject-parser
-    # via shippinglabel
-domdf-python-tools==3.6.1
-    # via apeye
-    # via apeye-core
-    # via dist-meta
-    # via dom-toml
-    # via pyproject-parser
-    # via shippinglabel
 dulwich==0.21.7
     # via poetry
 fastjsonschema==2.19.1
@@ -58,13 +39,8 @@ fastjsonschema==2.19.1
 filelock==3.15.1
     # via cachecontrol
     # via virtualenv
-handy-archives==0.1.4
-    # via dist-meta
 idna==3.4
-    # via apeye-core
     # via requests
-importlib-metadata==8.4.0
-    # via keyring
 iniconfig==2.0.0
     # via pytest
 installer==0.7.0
@@ -72,6 +48,9 @@ installer==0.7.0
 isort==5.12.0
 jaraco-classes==3.4.0
     # via keyring
+jeepney==0.8.0
+    # via keyring
+    # via secretstorage
 keyring==24.3.1
     # via poetry
 more-itertools==10.3.0
@@ -80,17 +59,11 @@ msgpack==1.0.8
     # via cachecontrol
 mypy-extensions==1.0.0
     # via black
-natsort==8.3.1
-    # via domdf-python-tools
-    # via pyproject-parser
 packaging==23.1
     # via black
     # via build
-    # via dist-meta
     # via poetry
-    # via pyproject-parser
     # via pytest
-    # via shippinglabel
 pathspec==0.11.1
     # via black
 pexpect==4.9.0
@@ -98,10 +71,8 @@ pexpect==4.9.0
 pkginfo==1.11.1
     # via poetry
 platformdirs==3.5.1
-    # via apeye
     # via black
     # via poetry
-    # via shippinglabel
     # via virtualenv
 pluggy==1.5.0
     # via pytest
@@ -115,50 +86,40 @@ poetry-plugin-export==1.8.0
     # via poetry
 ptyprocess==0.7.0
     # via pexpect
+pycparser==2.22
+    # via cffi
 pydantic==1.10.8
     # via poetry2rye
 pyproject-hooks==1.1.0
     # via build
     # via poetry
-pyproject-parser==0.11.1
-    # via poetry2rye
 pytest==8.2.2
 python-slugify==8.0.1
     # via poetry2rye
-pywin32-ctypes==0.2.3
-    # via keyring
 rapidfuzz==3.9.3
     # via cleo
 requests==2.31.0
-    # via apeye
     # via cachecontrol
     # via poetry
     # via requests-toolbelt
 requests-toolbelt==1.0.0
     # via poetry
+secretstorage==3.3.3
+    # via keyring
 shellingham==1.5.4
     # via poetry
-shippinglabel==1.5.0
-    # via pyproject-parser
 text-unidecode==1.3
     # via python-slugify
-tomli==2.0.1
-    # via dom-toml
 tomlkit==0.11.8
     # via poetry
     # via poetry2rye
 trove-classifiers==2024.5.22
     # via poetry
 typing-extensions==4.11.0
-    # via domdf-python-tools
     # via poetry2rye
     # via pydantic
-    # via pyproject-parser
-    # via shippinglabel
 urllib3==2.0.2
     # via dulwich
     # via requests
 virtualenv==20.24.1
     # via poetry
-zipp==3.20.1
-    # via importlib-metadata

--- a/requirements.lock
+++ b/requirements.lock
@@ -10,67 +10,16 @@
 #   universal: false
 
 -e file:.
-apeye==1.3.0
-    # via shippinglabel
-apeye-core==1.1.2
-    # via apeye
-    # via pyproject-parser
-attrs==23.1.0
-    # via pyproject-parser
-certifi==2023.5.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-dist-meta==0.8.0
-    # via shippinglabel
-dom-toml==2.0.0
-    # via pyproject-parser
-    # via shippinglabel
-domdf-python-tools==3.6.1
-    # via apeye
-    # via apeye-core
-    # via dist-meta
-    # via dom-toml
-    # via pyproject-parser
-    # via shippinglabel
-handy-archives==0.1.4
-    # via dist-meta
-idna==3.4
-    # via apeye-core
-    # via requests
-natsort==8.3.1
-    # via domdf-python-tools
-    # via pyproject-parser
-packaging==23.1
-    # via dist-meta
-    # via pyproject-parser
-    # via shippinglabel
-platformdirs==3.5.1
-    # via apeye
-    # via shippinglabel
 poetry-core==1.9.0
     # via poetry2rye
 pydantic==1.10.8
     # via poetry2rye
-pyproject-parser==0.11.1
-    # via poetry2rye
 python-slugify==8.0.1
     # via poetry2rye
-requests==2.31.0
-    # via apeye
-shippinglabel==1.5.0
-    # via pyproject-parser
 text-unidecode==1.3
     # via python-slugify
-tomli==2.0.1
-    # via dom-toml
 tomlkit==0.11.8
     # via poetry2rye
 typing-extensions==4.11.0
-    # via domdf-python-tools
     # via poetry2rye
     # via pydantic
-    # via pyproject-parser
-    # via shippinglabel
-urllib3==2.0.2
-    # via requests

--- a/src/poetry2rye/convert.py
+++ b/src/poetry2rye/convert.py
@@ -17,8 +17,8 @@ def read_name_email(string: str) -> dict[str, str]:
     return {"name": name, "email": email[1:-1]}
 
 
-def convert(project_path: Path) -> None:
-    poetry_project = PoetryProject(project_path)
+def convert(project_path: Path, ensure_src: bool = True) -> None:
+    poetry_project = PoetryProject(project_path, ensure_src=ensure_src)
 
     project_sec = {}
     urls_sec = {}
@@ -138,12 +138,14 @@ def convert(project_path: Path) -> None:
 
     if (project_path / "poetry.lock").exists():
         os.remove(project_path / "poetry.lock")
-    if not (project_path / "src").exists():
-        (project_path / "src").mkdir()
-        shutil.move(
-            poetry_project.module_path,
-            project_path / "src" / poetry_project.module_name,
-        )
+
+    if ensure_src:
+        if not (project_path / "src").exists():
+            (project_path / "src").mkdir()
+            shutil.move(
+                poetry_project.module_path,
+                project_path / "src" / poetry_project.module_name,
+            )
 
 
 def _convert_scripts(poetry_scripts):

--- a/src/poetry2rye/main.py
+++ b/src/poetry2rye/main.py
@@ -13,8 +13,13 @@ def handle_mig(args: Any) -> None:
     path: Path = args.path
     project_path = Path(path).absolute()
     ensure_src: bool = not args.ignore_src
+    virtual_project: bool = args.virtual
 
-    convert(project_path=project_path, ensure_src=ensure_src)
+    convert(
+        project_path=project_path,
+        ensure_src=ensure_src,
+        virtual_project=virtual_project,
+    )
 
     print("done")
 
@@ -65,6 +70,12 @@ def main(args: Optional[list[str]] = None):
     mig_parser.add_argument(
         "--ignore-src",
         help='use it to ignore the checking/creating "src/" directory during migration process (by default will check and create).',
+        action="store_true",
+        default=False,
+    )
+    mig_parser.add_argument(
+        "--virtual",
+        help="perform migration by considering as a virtual package.\n\nA virtual package can have dependencies but is itself not installed as a Python package.  It also cannot be published.",
         action="store_true",
         default=False,
     )

--- a/src/poetry2rye/main.py
+++ b/src/poetry2rye/main.py
@@ -10,10 +10,11 @@ from poetry2rye.utils import get_biggest_backup_num
 
 
 def handle_mig(args: Any) -> None:
-    path = args.path
+    path: Path = args.path
     project_path = Path(path).absolute()
+    ensure_src: bool = not args.ignore_src
 
-    convert(project_path)
+    convert(project_path=project_path, ensure_src=ensure_src)
 
     print("done")
 
@@ -60,6 +61,13 @@ def main(args: Optional[list[str]] = None):
 
     mig_parser.add_argument("path")
     mig_parser.set_defaults(func=handle_mig)
+
+    mig_parser.add_argument(
+        "--ignore-src",
+        help='use it to ignore the checking/creating "src/" directory during migration process (by default will check and create).',
+        action="store_true",
+        default=False,
+    )
 
     get_backup_parser = subparsers.add_parser(
         "get-backup", help="get a backup of a Poetry project"

--- a/src/poetry2rye/project.py
+++ b/src/poetry2rye/project.py
@@ -1,9 +1,9 @@
 import re
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
-import pyproject_parser
 import slugify
 from poetry.core.constraints.version.parser import parse_constraint
 from poetry.core.constraints.version.version_constraint import VersionConstraint
@@ -101,10 +101,12 @@ class PoetryProject:
         if not (self.path / "pyproject.toml").exists():
             raise ControlledError("pyproject.toml not found")
 
-        self.pyproject = pyproject_parser.PyProject.load(self.path / "pyproject.toml")
-        self.poetry = self.pyproject.tool["poetry"]
+        with open(self.path / "pyproject.toml", "rb") as file:
+            self.pyproject = tomllib.load(file)
 
-        if self.pyproject.project is not None:
+        self.poetry = self.pyproject["tool"]["poetry"]
+
+        if self.pyproject.get("project") is not None:
             raise ControlledError(
                 "this pyproject.toml has a project section.\n"
                 "for now, poetry2rye only supports pyproject.toml written using "

--- a/src/poetry2rye/project.py
+++ b/src/poetry2rye/project.py
@@ -104,7 +104,10 @@ class PoetryProject:
         with open(self.path / "pyproject.toml", "rb") as file:
             self.pyproject = tomllib.load(file)
 
-        self.poetry = self.pyproject["tool"]["poetry"]
+        try:
+            self.poetry = self.pyproject["tool"]["poetry"]
+        except Exception:
+            raise ControlledError("this project is not managed by poetry !")
 
         if self.pyproject.get("project") is not None:
             raise ControlledError(

--- a/tests/test-dirs/mig-p0/pyproject.toml
+++ b/tests/test-dirs/mig-p0/pyproject.toml
@@ -4,12 +4,14 @@ version = "0.1.0"
 description = ""
 authors = [{name = "nahco314",email = "nahco3_ta@yahoo.co.jp"}]
 readme = "README.md"
-dependencies = []
+dependencies = [
+]
 requires-python = ">=3.12,<4.0"
 
 
 [tool.rye]
 managed = true
+virtual = false
 
 [tool.hatch]
 [tool.hatch.metadata]

--- a/tests/test-dirs/mig-p1/pyproject.toml
+++ b/tests/test-dirs/mig-p1/pyproject.toml
@@ -4,13 +4,20 @@ version = "0.1.0"
 description = ""
 authors = [{name = "nahco314",email = "nahco3_ta@yahoo.co.jp"}]
 readme = "README.md"
-dependencies = ["numpy>=2.0.0,<3.0.0", "sortedcontainers==2.4.0", "pyproject-parser @ git+https://github.com/repo-helper/pyproject-parser"]
+dependencies = [
+    "numpy>=2.0.0,<3.0.0",
+    "sortedcontainers==2.4.0",
+    "pyproject-parser @ git+https://github.com/repo-helper/pyproject-parser",
+]
 requires-python = ">=3.12,<4.0"
 
 
 [tool.rye]
 managed = true
-dev-dependencies = ["typing-extensions>=4.12.2,<5.0.0"]
+virtual = false
+dev-dependencies = [
+    "typing-extensions>=4.12.2,<5.0.0",
+]
 
 [tool.hatch]
 [tool.hatch.metadata]

--- a/tests/test-dirs/mig-p2/pyproject.toml
+++ b/tests/test-dirs/mig-p2/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 description = ""
 authors = [{name = "Your Name",email = "you@example.com"}]
 readme = "README.md"
-dependencies = []
+dependencies = [
+]
 requires-python = ">=3.12,<4.0"
 
 [project.scripts]
@@ -13,6 +14,7 @@ p2 = "p2.main:main"
 
 [tool.rye]
 managed = true
+virtual = false
 
 [tool.hatch]
 [tool.hatch.metadata]


### PR DESCRIPTION
- `--ignore-src` : I've added this option to give the ability to choose to ignore checking and creating `src/` directory in migration process for a project, because of the keeping the project's files structure and avoid many changes in **legacy** projects.
- `tomllib` : to reading the content of `pyproject.toml` file, I've used the `tomlib` library, which is **built-in** in python > 3.11. It also fixes the issues with previous library and remove extra libraries.
- `--virtual` : support virtual packages which using `rye` only as dependency manager, and the package itself is not for build.